### PR TITLE
Move test start time into first callback process

### DIFF
--- a/src/comm/bench-client.js
+++ b/src/comm/bench-client.js
@@ -80,7 +80,8 @@ function doTest(msg) {
         var rounds   = Array(msg.numb).fill(0);
         var promises = [];
         var idx       = 0;
-        var start     = process.uptime();
+        var start;
+        var initComplete = false;
         var sleepTime = (msg.tps > 0) ? 1000/msg.tps : 0;
 
         console.log('start client ' + process.pid +  (cb.info ? (':' + cb.info) : ''));
@@ -93,6 +94,10 @@ function doTest(msg) {
                     return Promise.resolve(result);
                 }));
                 idx++;
+                if (!initComplete) {
+                    initComplete = true;
+                    start = process.uptime();
+                }
                 return rateControl(sleepTime, start, idx);
             });
         }, cb.init(blockchain, context, msg.args))


### PR DESCRIPTION
Within the bench client, the start time is taken before the test rounds commence.

The cb.init() is run first and then the rounds progress.

Because the cb.init() may take some time, this means that the start time becomes invalid and consequently the rate control will not work as intended.

For example:
 - if sleep time = 0.5s
 - start time = 0
 - cb.init() takes 10s to complete
Then the rateControl will not work correctly for the first 20 transactions since the time per transaction has not caught up with the cb.init() delay. The result of this is that the initial set of transactions will be sent immediately, which is not the intention.

This pull request moves the setting of the start time used in the rate control into the round reduction loop, and is set on the first main test item.