### PR TITLE
support launching client only once for multiple test rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ npm test -- simple -c ./benchmark/simple/config.json -n ./benchmark/simple/fab
 In this way, multiple clients can be launched on distributed hosts to run the same benchmark.
 
 1. Start the ZooKeeper service
-2. Launch clients on target machines separately by running `node ./src/comm/client/zoo-client.js zookeeper-server` or `npm npm run startclient -- zookeeper-server` . Time synchronization between target machines should be executed before launching the clients.  
+2. Launch clients on target machines separately by running `node ./src/comm/client/zoo-client.js zookeeper-server` or `npm run startclient -- zookeeper-server` . Time synchronization between target machines should be executed before launching the clients.  
 
     Example:
     ```bash

--- a/benchmark/drm/config.json
+++ b/benchmark/drm/config.json
@@ -19,13 +19,11 @@
         "label" : "publish",
         "txNumbAndTps" : [[1,1]],
         "arguments": {  "itemBytes": 2048000 },
-        "callback" : "benchmark/drm/publish.js",
-        "out" : "itemIDs"
+        "callback" : "benchmark/drm/publish.js"
       },
       {
         "label" : "query",
         "txNumbAndTps" : [[1,1]],
-        "arguments": { "itemIDs" : "*#out"},
         "callback" : "benchmark/drm/query.js"
       }]
   },

--- a/benchmark/drm/publish.js
+++ b/benchmark/drm/publish.js
@@ -14,6 +14,10 @@ module.exports.info  = "publishing digital items";
 
 var bc, contx;
 var itemBytes = 1024;   // default value
+var ids = [];           // save the generated item ids
+
+module.exports.ids = ids;
+
 module.exports.init = function(blockchain, context, args) {
     if(args.hasOwnProperty('itemBytes') ) {
        itemBytes = args.itemBytes;
@@ -39,15 +43,13 @@ module.exports.run = function() {
 }
 
 module.exports.end = function(results) {
-    var ids = [];
     for (let i in results){
         let stat = results[i];
         if(stat.status === 'success') {
             ids.push(stat.result.toString());
         }
     }
-
-    return Promise.resolve(ids);
+    return Promise.resolve();
 }
 /**********************
 * save published items' identity

--- a/benchmark/drm/query.js
+++ b/benchmark/drm/query.js
@@ -13,13 +13,10 @@ module.exports.info  = "querying digital items";
 var bc, contx;
 var itemIDs;
 module.exports.init = function(blockchain, context, args) {
-    if(!args.hasOwnProperty('itemIDs') || args['itemIDs'].length === 0) {
-        return Promise.reject(new Error("drm.query - 'itemIDs' is missed in the arguments"));
-    }
-
+    var publish = require('./publish.js');
     bc      = blockchain;
     contx   = context;
-    itemIDs = args.itemIDs;
+    itemIDs = publish.ids;
     return Promise.resolve();
 }
 

--- a/benchmark/simple/config-fabric.json
+++ b/benchmark/simple/config-fabric.json
@@ -19,16 +19,8 @@
         "callback" : "benchmark/simple/open.js"
       },
       {
-        "label" : "open",
-        "txNumbAndTps" : [[5000,400]],
-        "arguments": {  "money": 10000 },
-        "callback" : "benchmark/simple/open.js",
-        "out" : "accounts"
-      },
-      {
         "label" : "query",
         "txNumbAndTps" : [[5000,300], [5000,400]],
-        "arguments": {  "accounts":  "*#out" },
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config-sawtooth.json
+++ b/benchmark/simple/config-sawtooth.json
@@ -12,13 +12,11 @@
         "label" : "open",
         "txNumbAndTps" : [[100,1]],
         "arguments": {  "money": 10000 },
-        "callback" : "benchmark/simple/open.js",
-        "out" : "accounts"
+        "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
         "txNumbAndTps" : [[100, 1]],
-        "arguments": {  "accounts":  "*#out" },
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config-zookeeper.json
+++ b/benchmark/simple/config-zookeeper.json
@@ -21,13 +21,11 @@
         "label" : "open",
         "txNumbAndTps" : [[2000,200]],
         "arguments": {  "money": 10000 },
-        "callback" : "benchmark/simple/open.js",
-        "out" : "accounts"
+        "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
         "txNumbAndTps" : [[2000,200]],
-        "arguments": {  "accounts":  "*#out" },
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config.json
+++ b/benchmark/simple/config.json
@@ -21,16 +21,8 @@
         "callback" : "benchmark/simple/open.js"
       },
       {
-        "label" : "open",
-        "txNumbAndTps" : [[5000,400]],
-        "arguments": {  "money": 10000 },
-        "callback" : "benchmark/simple/open.js",
-        "out" : "accounts"
-      },
-      {
         "label" : "query",
         "txNumbAndTps" : [[5000,300], [5000,400]],
-        "arguments": {  "accounts":  "*#out" },
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/open.js
+++ b/benchmark/simple/open.js
@@ -30,5 +30,7 @@ module.exports.run = function() {
 }
 
 module.exports.end = function(results) {
-    return Promise.resolve(accounts);
+    return Promise.resolve();
 }
+
+module.exports.accounts = accounts;

--- a/benchmark/simple/query.js
+++ b/benchmark/simple/query.js
@@ -13,13 +13,10 @@ module.exports.info  = "querying accounts";
 var bc, contx;
 var accounts;
 module.exports.init = function(blockchain, context, args) {
-    if(!args.hasOwnProperty('accounts') || args['accounts'].length === 0) {
-        return Promise.reject(new Error("simple.query - 'accounts' is missed in the arguments"));
-    }
-
+    var open = require('./open.js');
     bc       = blockchain;
     contx    = context;
-    accounts = args.accounts;
+    accounts = open.accounts;
     return Promise.resolve();
 }
 

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -24,26 +24,28 @@ var Client  = require('./client/client.js');
 var blockchain, monitor, report, client;
 var resultsbyround = [];    // processed output of each test round
 var round = 0;              // test round
-var cache = {};             // memory cache to store defined output from child process, so different test case could exchange data if needed
-                            // this should only be used to exchange small amount of data
+//var cache = {};             // memory cache to store defined output from child process, so different test case could exchange data if needed
+                             // this should only be used to exchange small amount of data
+                             // obsoleted
 var demo = require('../gui/src/demo.js')
 var absConfigFile, absNetworkFile;
 var absCaliperDir = path.join(__dirname, '../..');
 
+// obsoleted
 /**
 * Read cached data by key name
 * @key {string}
 * @return {Object}, cached data
 */
-function getCache(key) {
+/*function getCache(key) {
     return cache[key];
-}
+}*/
 
 /**
 * Write data in the global cache
 * @data {Object}, key/value
 */
-function putCache(data) {
+/*function putCache(data) {
     if(typeof data === 'undefined') {
         return;
     }
@@ -63,7 +65,7 @@ function putCache(data) {
             cache[data.key] = [data.value];
         }
     }
-}
+}*/
 
 /**
 * Start a default test flow to run the tests
@@ -232,6 +234,7 @@ function defaultTest(args, final) {
                               cb  : args.callback,
                               config: configPath
                            };
+                /* obsoleted
                 for( let key in args.arguments) {
                     if(args.arguments[key] === "*#out") { // from previous cached data
                         msg.args[key] = getCache(key);
@@ -239,7 +242,7 @@ function defaultTest(args, final) {
                 }
                 if (args.hasOwnProperty('out')) {
                     msg.out = args.out;
-                }
+                }*/
                 tests.push(msg);
             }
             var testIdx = 0;
@@ -350,7 +353,7 @@ function defaultTest(args, final) {
 *     valid  : {min: , max: },            // min/max time of tx becoming valid
 *     delay  : {min: , max: , sum: },     // min/max/sum time of txs' processing delay
 *     throughput : {time: ,...}           // tps of each time slot
-*     out: {key, value}                   // output that should be cached for following tests
+*     // obsoleted out: {key, value}                   // output that should be cached for following tests
 * }
 * @opt, operation being tested
 * @return {Promise}
@@ -360,9 +363,9 @@ function processResult(results, opt){
     try{
         Blockchain.mergeDefaultTxStats(results);
         var r = results[0];
-        for(let i = 0 ; i < r.out.length ; i++) {
+        /*for(let i = 0 ; i < r.out.length ; i++) {
             putCache(r.out[i]);
-        }
+        }*/
         r['opt'] = opt;
 
         resultsbyround.push(r);

--- a/src/comm/client/client-util.js
+++ b/src/comm/client/client-util.js
@@ -12,62 +12,133 @@ const CLIENT_LOCAL = 'local';
 const CLIENT_ZOO   = 'zookeeper';
 
 var zkUtil     = require('./zoo-util.js');
-var processes  = [];
-function startTest(number, message, queryCB, results) {
-    var promises = [];
+var processes  = {}; // {pid:{obj, promise}}
+
+function setPromise(pid, isResolve, msg) {
+    var p = processes[pid];
+    if(p && p.promise && typeof p.promise !== 'undefined') {
+        if(isResolve) {
+            p.promise.resolve(msg);
+        }
+        else {
+            p.promise.reject(msg);
+        }
+    }
+}
+
+function pushResult(pid, data) {
+    var p = processes[pid];
+    if(p && p.results && typeof p.results !== 'undefined') {
+        p.results.push(data);
+    }
+}
+
+function queryCallback(pid, session, data) {
+    var p = processes[pid];
+    if(p && p.queryCB && typeof p.queryCB !== 'undefined') {
+        p.queryCB(session, data);
+    }
+}
+
+function launchClient(message, queryCB, results) {
     var path = require('path');
     var childProcess = require('child_process');
-    processes = [];
-    var txPerClient  = Math.floor(message.numb / number);
-    var tpsPerClient = Math.floor(message.tps / number);
-    if(txPerClient < 1) {
-        txPerClient = 1;
+    var child = childProcess.fork(path.join(__dirname, 'local-client.js'));
+    var pid   = child.pid.toString();
+    processes[pid] = {obj: child, results: results, queryCB: queryCB};
+
+    child.on('message', function(msg) {
+        if(msg.type === 'testResult') {
+            pushResult(pid, msg.data);
+            setPromise(pid, true, null);
+        }
+        else if(msg.type === 'error') {
+            setPromise(pid, false, new Error('Client encountered error:' + msg.data));
+        }
+        else if(msg.type === 'queryResult') {
+            queryCallback(pid, msg.session, msg.data);
+        }
+    });
+
+    child.on('error', function(){
+        setPromise(pid, false, new Error('Client encountered unexpected error'));
+    });
+
+    child.on('exit', function(){
+        console.log('Client exited');
+        setPromise(pid, true, null);
+    });
+}
+
+function startTest(number, message, queryCB, results) {
+    var count = 0;
+    for (var i in processes) {
+        count++;
     }
-    if(tpsPerClient < 1) {
-        tpsPerClient = 1;
+    if(count === number) {  // already launched clients
+        let txPerClient  = Math.floor(message.numb / number);
+        let tpsPerClient = Math.floor(message.tps / number);
+        if(txPerClient < 1) {
+            txPerClient = 1;
+        }
+        if(tpsPerClient < 1) {
+            tpsPerClient = 1;
+        }
+        message.numb = txPerClient;
+        message.tps  = tpsPerClient;
+
+        let promises = [];
+        for(let id in processes) {
+            let client = processes[id];
+            let p = new Promise((resolve, reject) => {
+                client['promise'] = {
+                    resolve: resolve,
+                    reject:  reject
+                }
+            });
+            promises.push(p);
+            client['results'] = results;
+            client['queryCB'] = queryCB;
+            client.obj.send(message);
+        }
+
+        return Promise.all(promises)
+                .then(()=>{
+                    // clear promises
+                    for(let client in processes) {
+                        delete client.promise;
+                    }
+                    return Promise.resolve();
+                })
+                .catch((err)=>{
+                    return Promise.reject(err);
+                });
+
     }
-    message.numb = txPerClient;
-    message.tps  = tpsPerClient;
+
+    // launch clients
+    processes = {};
     for(let i = 0 ; i < number ; i++) {
-        let p = new Promise( (resolve, reject) => {
-                        let child = childProcess.fork(path.join(__dirname, 'local-client.js'));
-                        processes.push(child);
-                        child.on('message', function(msg) {
-                            if(msg.type === 'testResult') {
-                                results.push(msg.data);
-                                resolve();
-                                child.kill();
-                            }
-                            else if(msg.type === 'error') {
-                                reject('client encountered error, ' + msg.data);
-                                child.kill();
-                            }
-                            else if(msg.type === 'queryResult') {
-                                queryCB(msg.session, msg.data);
-                            }
-                        });
-
-                        child.on('error', function(){
-                            reject('client encountered unexpected error');
-                        });
-
-                        child.on('exit', function(){
-                            console.log('client exited');
-                            resolve();
-                        });
-
-                        child.send(message);
-                    });
-        promises.push(p);
+        launchClient(message, queryCB, results);
     }
-    return Promise.all(promises);
+
+    // start test
+    return startTest(number, message, queryCB, results);
 }
 module.exports.startTest = startTest;
 
 function sendMessage(message) {
-    processes.forEach((client)=>{
-        client.send(message);
-    });
+    for(let pid in processes) {
+        processes[pid].obj.send(message);
+    }
     return processes.length;
 }
 module.exports.sendMessage = sendMessage;
+
+function stop() {
+    for(let pid in processes) {
+        processes[pid].obj.kill();
+    }
+    processes = {};
+}
+module.exports.stop = stop;

--- a/src/comm/client/client.js
+++ b/src/comm/client/client.js
@@ -114,9 +114,12 @@ var Client = class {
         switch(this.type) {
             case CLIENT_ZOO:
                 this._stopZoo();
+                break;
             case CLIENT_LOCAL:
+                clientUtil.stop();
+                break;
             default:
-                ; // nothing todo
+                ; // nothing to do
         }
         this.results = [];
     }
@@ -293,8 +296,13 @@ var Client = class {
 
     _stopZoo() {
         if(this.zoo && this.zoo.zk) {
-            this.zoo.zk.close();
-            this.zoo.hosts = [];
+            var msg = {type: 'quit'};
+            this._sendZooMessage(msg).then(()=>{
+                setTimeout(()=>{
+                    this.zoo.zk.close();
+                    this.zoo.hosts = [];
+                }, 1000);
+            })
         }
     }
 }

--- a/src/comm/client/local-client.js
+++ b/src/comm/client/local-client.js
@@ -87,7 +87,7 @@ function doTest(msg) {
         var initComplete = false;
         var sleepTime = (msg.tps > 0) ? 1000/msg.tps : 0;
 
-        console.log('start client ' + process.pid +  (cb.info ? (':' + cb.info) : ''));
+        console.log('Info: client ' + process.pid +  ' start test ' + (cb.info ? (':' + cb.info) : ''));
 
         return rounds.reduce(function(prev, item) {
             return prev.then( () => {
@@ -116,9 +116,9 @@ function doTest(msg) {
         })
         .then( (out) => {
             var stats = blockchain.getDefaultTxStats(bcResults);
-            if(msg.hasOwnProperty('out') && typeof out !== 'undefined') {
+            /* obsoleted if(msg.hasOwnProperty('out') && typeof out !== 'undefined') {
                 stats.out[0] = { key: msg['out'], value : out};
-            }
+            }*/
             return Promise.resolve(stats);
         });
     })

--- a/src/comm/client/zoo-client.js
+++ b/src/comm/client/zoo-client.js
@@ -118,6 +118,9 @@ function finish() {
 }
 
 function clear() {
+    // test
+    console.log("invoke here!!!");
+
     var promises = [];
     if(inNode !== '') {
         promises.push(zkUtil.removeChildrenP(zk, inNode, 'Failed to remove children due to'));
@@ -125,6 +128,7 @@ function clear() {
     if(outNode !== '') {
         promises.push(zkUtil.removeChildrenP(zk, outNode, 'Failed to remove children due to'));
     }
+    clientUtil.stop();
     return Promise.all(promises);
 }
 


### PR DESCRIPTION
1. only launch clients at the beginning of the first test round, and destroy them at the end of all tests
2. remove original cache mechanism since now different test rounds shares the same process,
3. modify the documents according to the change