### PR TITLE
modularise the rate control mechanism

### DIFF
--- a/benchmark/simple/config-fabric.json
+++ b/benchmark/simple/config-fabric.json
@@ -14,13 +14,15 @@
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[5000,100], [5000,200], [5000,300]],
+        "txNumber" : [5000, 5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 200}}, {"type": "fixed-rate", "opts": {"tps" : 300}}],
         "arguments": {  "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[5000,300], [5000,400]],
+        "txNumbAndTps" : [5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 300}}, {"type": "fixed-rate", "opts": {"tps" : 400}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config-iroha.json
+++ b/benchmark/simple/config-iroha.json
@@ -14,13 +14,15 @@
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[500,50]],
+        "txNumbAndTps" : [500],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 50}}],
         "arguments": {  "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[500,50]],
+        "txNumbAndTps" : [500],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 50}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config-sawtooth.json
+++ b/benchmark/simple/config-sawtooth.json
@@ -10,13 +10,15 @@
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[100,1]],
+        "txNumber" : [100],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 1}}],
         "arguments": {  "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[100, 1]],
+        "txNumber" : [100],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 1}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config-zookeeper.json
+++ b/benchmark/simple/config-zookeeper.json
@@ -19,13 +19,15 @@
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[2000,200]],
+        "txNumber" : [2000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 200}}],
         "arguments": {  "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[2000,200]],
+        "txNumber" : [2000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 200}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/benchmark/simple/config.json
+++ b/benchmark/simple/config.json
@@ -16,13 +16,15 @@
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[5000,100], [5000,200], [5000,300]],
-        "arguments": {  "money": 10000 },
+        "txNumber" : [5000, 5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 200}}, {"type": "fixed-rate", "opts": {"tps" : 300}}],
+        "arguments": { "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[5000,300], [5000,400]],
+        "txNumber" : [5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 300}}, {"type": "fixed-rate", "opts": {"tps" : 400}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -49,13 +49,15 @@ Below is a benchmark configuration file example:
     },
     "rounds": [{
         "label" : "open",
-        "txNumbAndTps" : [[5000,100], [5000,200], [5000,300]],
+        "txNumber" : [5000, 5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 100}}, {"type": "fixed-rate", "opts": {"tps" : 200}}, {"type": "fixed-rate", "opts": {"tps" : 300}}],
         "arguments": {  "money": 10000 },
         "callback" : "benchmark/simple/open.js"
       },
       {
         "label" : "query",
-        "txNumbAndTps" : [[5000,300], [5000,400]],
+        "txNumber" : [5000, 5000],
+        "rateControl" : [{"type": "fixed-rate", "opts": {"tps" : 300}}, {"type": "fixed-rate", "opts": {"tps" : 400}}],
         "callback" : "benchmark/simple/query.js"
       }]
   },
@@ -92,9 +94,10 @@ Below is a benchmark configuration file example:
       }
       ```
   * **label** : hint for the test. For example, you can use the transaction name as the label name to tell which transaction is mainly used to test the performance. The value is also used as the context name for *blockchain.getContext()*. For example, developers may want to test performance of different Fabric channels, in that case, tests with different label can be bound to different fabric channels.  
-  * **txNumbAndTps** : defines an array of sub-rounds with different transaction numbers or transaction generating speed. For example, [5000,400] means totally 5000 transactions will be generated and invoked at a speed of 400 transactions per second. In above example, actually 5 (not 2) test rounds are defined.
-  * **durationAndTps** : defines an array of sub-rounds with time based test runs. For example [150,400] means a performance test will run for 150 seconds, driven at a rate of 400 transactions per second. If specified in addition to txNumbAndTps, the durationTpsAndTrim option will take precedence. 
-  * **trim** : performs a trimming operation on the client results to eliminate the warm-up and cool-down phase being included within tests reports. If specified, the trim option will respect the round measurement. For example, if `txNumbAndTps` is the driving test mode the a value of 30 means the initial and final 30 transactions of the results from each client will be ignored when generating result statistics; if `durationAndTps` is being used, the the initial and final 30seconds of the the results fromeach client will be ignored.
+  * **txNumber** : defines an array of sub-rounds with different transaction numbers to be run in each round. For example, [5000,400] means totally 5000 transactions will be generated in the first round and 400 will be generated in the second. 
+  * **txDuration** : defines an array of sub-rounds with time based test runs. For example [150,400] means two runs will be made, the first test will run for 150 seconds, and the second will run for 400 seconds. If specified in addition to txNumber, the txDuration option will take precedence.
+  * **rateControl** : defines an array of custom rate controls to use during the benchmarking test sub-rounds. If not specified will default to 'fixed-rate' that will drive the benchmarking at a set 1 TPS rate. If defined, the rate control mechanism must exist, and may be provided with options to use to control the rate at which messages are sent, or to specify a message rate profile. For example `"rateControl" : [{"type": "my-rate-control", "opts": {"opt1" : x, "opt2" : [a,b,c]}}]` will use the rate controller `my-rate-control` and pass it the `opts` object that will be available for use within the rate controller for custom actions. Each round, specified within **txNumber** or **txDuration** must have a corresponding rate control item within the **rateControl** array.
+  * **trim** : performs a trimming operation on the client results to eliminate the warm-up and cool-down phase being included within tests reports. If specified, the trim option will respect the round measurement. For example, if `txNumber` is the driving test mode the a value of 30 means the initial and final 30 transactions of the results from each client will be ignored when generating result statistics; if `txDuration` is being used, the the initial and final 30seconds of the the results from each client will be ignored.
   * **arguments** : user defined arguments which will be passed directly to the user defined test module. 
   * **callback** : specifies the user defined module used in this test round. Please see [User defined test module](#user-defined-test-module) to learn more details.
 * **monitor** - defines the type of resource monitors and monitored objects, as well as the time interval for the monitoring.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Huawei-OSG/caliper"
   },
   "scripts": {
-    "test" : "node ./scripts/test.js",
-    "list" : "node ./scripts/list.js",
+    "test": "node ./scripts/test.js",
+    "list": "node ./scripts/list.js",
     "startclient": "node ./src/comm/client/zoo-client.js"
   },
   "engines": {
-    "node": ">=4.5.0",
+    "node": ">=8.0.0",
     "npm": ">=2.15.9"
   },
   "engine-strict": true,

--- a/src/comm/bench-flow.js
+++ b/src/comm/bench-flow.js
@@ -188,8 +188,8 @@ function createReport() {
     try{
         var r = 0;
         for(let i = 0 ; i < config.test.rounds.length ; i++) {
-            if(config.test.rounds[i].hasOwnProperty('txNumbAndTps')) {
-                r += config.test.rounds[i].txNumbAndTps.length;
+            if(config.test.rounds[i].hasOwnProperty('txNumber')) {
+                r += config.test.rounds[i].txNumber.length;
             }
         }
         report.addMetadata('Test Rounds', r);
@@ -220,14 +220,14 @@ function defaultTest(args, clientArgs, final) {
         var t = global.tapeObj;
         t.comment('\n\n###### testing \'' + args.label + '\' ######');
         var testLabel   = args.label;
-        var testRounds  = args.durationAndTps ? args.durationAndTps : args.txNumbAndTps;
+        var testRounds  = args.txDuration ? args.txDuration : args.txNumber;
         var tests = []; // array of all test rounds
         var configPath = path.relative(absCaliperDir, absNetworkFile);
         for(let i = 0 ; i < testRounds.length ; i++) {
             let msg = {
                 type: 'test',
                 label : args.label,
-                tps:  testRounds[i][1],
+                rateControl: args.rateControl[i] ? args.rateControl[i] : {type:'fixed-rate', 'opts' : {'tps': 1}},
                 trim: args.trim ? args.trim : 0,
                 args: args.arguments,
                 cb  : args.callback,
@@ -235,10 +235,10 @@ function defaultTest(args, clientArgs, final) {
              };
   
             // condition for time based or number based test driving
-            if (args.txNumbAndTps) {
-                msg.numb = testRounds[i][0];
-            } else if (args.durationAndTps) {
-                msg.duration = testRounds[i][0]
+            if (args.txNumber) {
+                msg.numb = testRounds[i];
+            } else if (args.txDuration) {
+                msg.txDuration = testRounds[i]
             } else {
                 return reject(new Error('Unspecified test driving mode'));
             }

--- a/src/comm/client/client-util.js
+++ b/src/comm/client/client-util.js
@@ -78,36 +78,33 @@ function launchClient(message, updateCB, results) {
 }
 
 function startTest(number, message, clientArgs, updates, results) {
-    let count = 0;
+    let count = 0;    
     for (let i in processes) {
         count++;
     }
     if(count === number) {  // already launched clients
         let txPerClient;
-        let tpsPerClient = Math.floor(message.tps / number);
-        if(tpsPerClient < 1) {
-            tpsPerClient = 1;
-        }
         if (message.numb) {
             // Run specified number of transactions
             txPerClient  = Math.floor(message.numb / number);
 
-            // trim should be based on client number if specified with txNumbAndTps
+            // trim should be based on client number if specified with txNumber
             if (message.trim) {
                 message.trim = Math.floor(message.trim / number);
             }
-        } else if (message.duration) {
-            // Run for time specified duration based on tps per client     
-            txPerClient  = Math.floor(message.duration * tpsPerClient);
+
+            if(txPerClient < 1) {
+                txPerClient = 1;
+            }
+            message.numb = txPerClient;
+        } else if (message.txDuration) {
+            // Run for time specified txDuration based on clients
+            // Do nothing, we run for the time specified within message.txDuration
         } else {
             return reject(new Error('Unconditioned transaction rate driving mode'));
         }
         
-        if(txPerClient < 1) {
-            txPerClient = 1;
-        }
-        message.numb = txPerClient;
-        message.tps  = tpsPerClient;
+        message.clients = number;
 
         let promises = [];
         let idx = 0;

--- a/src/comm/client/client.js
+++ b/src/comm/client/client.js
@@ -57,7 +57,8 @@ var Client = class {
     *              type: 'test',
     *              label : label name,
     *              numb:   total number of simulated txs,
-    *              tps:    number of txs generated per second,
+    *              rateControl: rate controller to use
+    *              trim:   trim options
     *              args:   user defined arguments,
     *              cb  :   path of the callback js file,
     *              config: path of the blockchain config file   // TODO: how to deal with the local config file when transfer it to a remote client (via zookeeper), as well as any local materials like cyrpto keys??
@@ -249,22 +250,17 @@ var Client = class {
             if(message.numb < 1) {
                 message.numb = 1;
             }
-            // trim should be based on client number if specified with txNumbAndTps
+            // trim should be based on client number if specified with txNumber
             if (message.trim) {
                 message.trim = Math.floor(message.trim / number);
             }
-        } else if (message.duration) {
-            // Run each client for time specified duration       
+        } else if (message.txDuration) {
+            // Run each client for time specified txDuration       
             // do nothing
         } else {
             return reject(new Error('Unconditioned transaction rate driving mode'));
         }
-
-        var tpsPerClient = Math.floor(message.tps / number);
-        if(tpsPerClient < 1) {
-            tpsPerClient = 1;
-        }
-        message.tps  = tpsPerClient;
+        
         message['clients'] = this.zoo.clientsPerHost;
         return this._sendZooMessage(message, clientArgs)
                 .then((number)=>{

--- a/src/comm/rate-control/fixedRate.js
+++ b/src/comm/rate-control/fixedRate.js
@@ -1,0 +1,44 @@
+
+'use strict'
+
+var RateInterface = require('./rateInterface.js')
+
+class BasicInterval extends RateInterface{
+    constructor(blockchain, opts) {
+        super(blockchain, opts);
+    }
+
+    /**
+     * Initialise the rate controller with a passed msg object
+     * - Only require the desired TPS from the standard msg options
+     * @param {*} msg 
+     */
+    init(msg) {
+        const tps = this.options.tps;
+        const tpsPerClient = msg.clients ? (tps / msg.clients) : tps;        
+        this.sleepTime = (tpsPerClient > 0) ? 1000/tpsPerClient : 0;
+    }
+
+    /**
+    * Perform the rate control action based on knowledge of the start time, current index, and current results.
+    * - Sleep a suitable time according to the required transaction generation time
+    * @param start {number}, generation time of the first test transaction
+    * @param txSeq {number}, sequence number of the current test transaction
+    * @param currentResults {Array}, current result set
+    * @return {promise}
+    */
+    applyRateControl(start, idx, currentResults) {
+        if(this.sleepTime === 0) {
+            return Promise.resolve();
+        }
+        var diff = (this.sleepTime * idx - (Date.now() - start));
+        if( diff > 5) {
+            return new Promise(resolve => setTimeout(resolve, diff));
+        }
+        else {
+            return Promise.resolve();
+        }
+    }
+}
+
+module.exports = BasicInterval;

--- a/src/comm/rate-control/rateControl.js
+++ b/src/comm/rate-control/rateControl.js
@@ -1,0 +1,38 @@
+'use strict'
+
+var RateControl = class {
+    constructor(rateControl, blockchain) {
+        console.log('*****', rateControl);
+        switch (rateControl.type) {
+            case 'fixed-rate':
+                var interval = require('./fixedRate.js');
+                this.controller = new interval(blockchain, rateControl.opts);
+                break
+            default:
+                throw new Error('Unknown rate control type ' + rateControl.type);
+        }
+    }
+
+    /**
+    * Initialise the rate controller with a passed msg object
+    * @param msg
+    * @return {Promise}
+    */
+    init(msg) {
+        return this.controller.init(msg);
+    }
+
+    /**
+     * Perform the rate control action based on knowledge of the start time, current index, and current results.
+     * @param {*} start
+     * @param {*} idx
+     * @param {*} results
+     * @return Promise
+     */
+    applyRateControl(start, idx, results) {
+        return this.controller.applyRateControl(start, idx, results);
+    }
+
+}
+
+module.exports = RateControl;

--- a/src/comm/rate-control/rateInterface.js
+++ b/src/comm/rate-control/rateInterface.js
@@ -1,0 +1,28 @@
+'use strict'
+
+class RateInterface {
+    constructor(blockchain, opts) {
+        this.blockchain = blockchain;
+        this.options = opts;
+    }
+
+    /**
+     * Initialise the rate controller with a passed msg object
+     * @param {*} msg 
+     */
+    init(msg) {
+        throw new Error('init is not implemented for this blockchain system');
+    }    
+
+    /**
+     * Perform the rate control action based on knowledge of the start time, current index, and current results.
+     * @param {*} start 
+     * @param {*} idx 
+     * @param {*} results 
+     */
+    applyRateControl(start, idx, results) {
+        throw new Error('applyRateControl is not implemented for this blockchain system');
+    }
+}
+
+module.exports = RateInterface;


### PR DESCRIPTION
At present the rate control mechanism is a simple 'TPS' rate control. A basic TPS control is good for driving simple tests at a set rate, however it has limitations in that:
- timeouts can occur
- it may be desired to follow a set profile (ie a sine-wave/step-wave profile)
- it may be desired to load the system in a different manner

I have been using a custom rate controller that loads a set number of transactions and maintains a set level of these transactions by adjusting the TPS, which has the benefit of never timing out and the results yield a 'maximum TPS' based on the set loading of transactions that are being processed.

To enable the above I modularised the rate component and would like to submit this modularisation back for consideration to be included in the main Caliper repository.

Users will then be able to submit their own rate controllers for experimentation.

The changes include:
- Modularisation of the rate component
- Documentation of how to specify a rate component
- Default to the 'basic-interval' rate limit, which is the rate limit being used by Caliper.