### PR TITLE
Make GOPATH configurable in a backward compatible way

### DIFF
--- a/docs/Fabric Configuration.md
+++ b/docs/Fabric Configuration.md
@@ -57,7 +57,9 @@ The fabric configuration is a json file which defines a fabric object with six m
 }
 ```
 
-* **chaincodes**: defines one or more chaincodes, those chaincodes can be installed and instantiated on all peers of the specific channel by calling *Blockchain.installSmartContract()* function.
+* **chaincodes**: defines one or more chaincodes, those chaincodes can be installed and instantiated on all peers of the specific channel by calling *Blockchain.installSmartContract()* function.  
+  The *path* attribute is relative to the *caliper/src* folder, since *$GOPATH* is temporarily set to the caliper root folder during benchmark execution. If you would like to install a Golang chaincode from a previously set *$GOPATH*, then set the *OVERWRITE_GOPATH* environment variable to *FALSE* before running the benchmark:  
+  ```GOPATH=~/mygopath OVERWRITE_GOPATH=FALSE node main.js```
 ```json
 {
   "chaincodes": [

--- a/src/fabric/util.js
+++ b/src/fabric/util.js
@@ -65,9 +65,12 @@ module.exports.storePathForOrg = function(org) {
 	return module.exports.KVS + '_' + org;
 };
 
-// temporarily set $GOPATH to the test fixture folder
+// temporarily set $GOPATH to the test fixture folder unless specified otherwise
 module.exports.setupChaincodeDeploy = function() {
-	process.env.GOPATH = path.join(__dirname, rootpath);
+    if (process.env.OVERWRITE_GOPATH === 'undefined'
+        || process.env.OVERWRITE_GOPATH.toString().toUpperCase() === 'TRUE') {
+        process.env.GOPATH = path.join(__dirname, rootpath);
+    }
 };
 
 // specifically set the values to defaults because they may have been overridden when


### PR DESCRIPTION
Currently, Caliper temporarily sets `GOPATH` to the Caliper root directory during benchmark execution. This makes it impossible to install Golang chaincodes from outside the `caliper/src` directory structure. 

However, this would be desirable when, for example, we want to store our chaincodes for benchmarking in a different repository, outside of Caliper (and do not want to copy them to `caliper/src` before benchmarking).

Related issue: #53 

To fix this issue, I added the option to leave `GOPATH` unchanged if the user sets the `OVERWRITE_GOPATH `environment variable to `FALSE`. If this environment variable is _undefined_ or explicitly set to `TRUE`, then Caliper will use its root directory as `GOPATH` for backward compatibility reason.

This behaviour is also documented in the Fabric configuration document. 